### PR TITLE
New feature: `purge` and `sync` commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "darwin"
       ],
       "dependencies": {
+        "async": "^3.2.4",
         "cli-diff": "^1.0.0",
         "prompts": "^2.4.2",
         "semver": "^7.3.7",
@@ -37,6 +38,7 @@
       },
       "devDependencies": {
         "@tsconfig/node14": "^1.0.3",
+        "@types/async": "^3.2.15",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^29.0.1",
         "@types/prompts": "^2.0.14",
@@ -1273,6 +1275,12 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "node_modules/@types/async": {
+      "version": "3.2.15",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.15.tgz",
+      "integrity": "sha512-PAmPfzvFA31mRoqZyTVsgJMsvbynR429UTTxhmfsUCrWGh3/fxOrzqBtaTPJsn4UtzTv4Vb0+/O7CARWb69N4g==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -1733,6 +1741,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/babel-jest": {
       "version": "29.0.3",
@@ -6079,6 +6092,12 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "@types/async": {
+      "version": "3.2.15",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.15.tgz",
+      "integrity": "sha512-PAmPfzvFA31mRoqZyTVsgJMsvbynR429UTTxhmfsUCrWGh3/fxOrzqBtaTPJsn4UtzTv4Vb0+/O7CARWb69N4g==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.19",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -6410,6 +6429,11 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
+    },
+    "async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "babel-jest": {
       "version": "29.0.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "predocs": "npm run format",
     "postdocs": "npm run docs:purge",
     "docs:purge": "npm run tpv purge -- -y",
-    "postdocs:purge": "npm run tpv sync -- -y --symlinks",
+    "postdocs:purge": "npm run docs:sync",
+    "docs:sync": "npm run tpv sync -- -y --symlinks",
     "tpv": "ts-node src/cli.ts",
     "tpv:dist": "node dist/cli.js"
   },
@@ -65,6 +66,7 @@
     "darwin"
   ],
   "dependencies": {
+    "async": "^3.2.4",
     "cli-diff": "^1.0.0",
     "prompts": "^2.4.2",
     "semver": "^7.3.7",
@@ -72,6 +74,7 @@
   },
   "devDependencies": {
     "@tsconfig/node14": "^1.0.3",
+    "@types/async": "^3.2.15",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^29.0.1",
     "@types/prompts": "^2.0.14",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "prebuild": "npm run format",
     "docs": "typedoc",
     "predocs": "npm run format",
+    "postdocs": "npm run docs:purge",
+    "docs:purge": "npm run tpv purge -- -y",
+    "postdocs:purge": "npm run tpv sync -- -y --symlinks",
     "tpv": "ts-node src/cli.ts",
     "tpv:dist": "node dist/cli.js"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,6 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 export const cli = yargs(hideBin(process.argv))
-    .parserConfiguration({ 'duplicate-arguments-array': false })
     .commandDir('commands', { extensions: ['ts', 'js'] })
     .strictCommands()
     .demandCommand(1, '')

--- a/src/commands/builders.ts
+++ b/src/commands/builders.ts
@@ -1,4 +1,4 @@
-import { findFile, isDir } from '../utils';
+import { findFile, findTsConfigFile, isDir } from '../utils';
 import { join, resolve } from 'path';
 
 export const out = {
@@ -6,10 +6,11 @@ export const out = {
     normalize: true,
     description: 'path to your typedoc output directory',
     defaultDescription: `"docs" (if not set in config)`,
-    coerce: (path: string) => {
+    coerce: async (path: string): Promise<string> => {
         path = resolve(path);
 
-        if (!isDir(path)) throw new Error(`Directory does not exist: ${path}`);
+        if (!(await isDir(path)))
+            throw new Error(`Directory does not exist: ${path}`);
 
         return path;
     },
@@ -20,7 +21,7 @@ export const typedoc = {
     normalize: true,
     description: 'path to your typedoc config',
     default: '.',
-    coerce: (path: string) =>
+    coerce: (path: string): Promise<string> =>
         findFile(path, [
             'typedoc.json',
             'typedoc.js',
@@ -34,7 +35,7 @@ export const tsconfig = {
     normalize: true,
     description: 'path to your tsconfig',
     default: '.',
-    coerce: (path: string) => findFile(path, true),
+    coerce: (path: string): string => findTsConfigFile(path),
 };
 
 export const options = { out, typedoc, tsconfig };

--- a/src/commands/builders.ts
+++ b/src/commands/builders.ts
@@ -1,0 +1,47 @@
+import { findFile, isDir } from '../utils';
+import { join, resolve } from 'path';
+
+export const out = {
+    type: 'string' as const,
+    normalize: true,
+    description: 'path to your typedoc output directory',
+    defaultDescription: `"docs" (if not set in config)`,
+    coerce: (path: string) => {
+        path = resolve(path);
+
+        if (!isDir(path)) throw new Error(`Directory does not exist: ${path}`);
+
+        return path;
+    },
+};
+
+export const typedoc = {
+    type: 'string' as const,
+    normalize: true,
+    description: 'path to your typedoc config',
+    default: '.',
+    coerce: (path: string) =>
+        findFile(path, [
+            'typedoc.json',
+            'typedoc.js',
+            join('.config', 'typedoc.js'),
+            join('.config', 'typedoc.json'),
+        ]),
+};
+
+export const tsconfig = {
+    type: 'string' as const,
+    normalize: true,
+    description: 'path to your tsconfig',
+    default: '.',
+    coerce: (path: string) => findFile(path, true),
+};
+
+export const options = { out, typedoc, tsconfig };
+
+export const yes = {
+    alias: 'y',
+    type: 'boolean' as const,
+    description: 'automatically confirm prompts',
+    default: false,
+};

--- a/src/commands/builders.ts
+++ b/src/commands/builders.ts
@@ -6,8 +6,10 @@ export const out = {
     normalize: true,
     description: 'path to your typedoc output directory',
     defaultDescription: `"docs" (if not set in config)`,
-    coerce: async (path: string): Promise<string> => {
-        path = resolve(path);
+    coerce: async (path: string | string[]): Promise<string> => {
+        path = resolve(
+            typeof path === 'string' ? path : (path.at(-1) as string)
+        );
 
         if (!(await isDir(path)))
             throw new Error(`Directory does not exist: ${path}`);
@@ -21,13 +23,15 @@ export const typedoc = {
     normalize: true,
     description: 'path to your typedoc config',
     default: '.',
-    coerce: (path: string): Promise<string> =>
-        findFile(path, [
+    coerce: (path: string | string[]): Promise<string> => {
+        path = typeof path === 'string' ? path : (path.at(-1) as string);
+        return findFile(path, [
             'typedoc.json',
             'typedoc.js',
             join('.config', 'typedoc.js'),
             join('.config', 'typedoc.json'),
-        ]),
+        ]);
+    },
 };
 
 export const tsconfig = {
@@ -35,7 +39,10 @@ export const tsconfig = {
     normalize: true,
     description: 'path to your tsconfig',
     default: '.',
-    coerce: (path: string): string => findTsConfigFile(path),
+    coerce: (path: string | string[]): string => {
+        path = typeof path === 'string' ? path : (path.at(-1) as string);
+        return findTsConfigFile(path);
+    },
 };
 
 export const options = { out, typedoc, tsconfig };

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -1,0 +1,162 @@
+import { version } from 'typedoc-plugin-versions';
+import {
+    loadMetadata,
+    refreshMetadata,
+    getSemanticVersion,
+    getVersionAlias,
+} from 'typedoc-plugin-versions/src/etc/utils';
+import { rmSync } from 'fs-extra';
+import { join, relative, resolve } from 'path';
+import { EOL } from 'os';
+import prompts from 'prompts';
+import { gt } from 'semver';
+import { Argv } from 'yargs';
+import { options, yes } from './builders';
+import { getOptions, isDir } from '../utils';
+import { Args, refreshedMetadata } from '../';
+
+export const command = ['purge [ranges..]'];
+export const description = 'purge old doc builds';
+export const builder = (yargs: Argv) =>
+    yargs.options({
+        stale: {
+            alias: 's',
+            type: 'boolean' as const,
+            description: 'purge stale dev versions',
+            default: true,
+        },
+        // sync: {
+        //     alias: 's',
+        //     type: 'boolean',
+        //     description: 'synchronize metadata and symlinks',
+        //     default: true,
+        // },
+        // 'symlinks': {
+        //     alias: 'symlinks',
+        //     type: 'boolean',
+        //     description: 'always synchronize symlinks even if no metadata changes detected',
+        //     default: false
+        // },
+        // 'major-versions': {
+        //     alias: 'major',
+        //     type: 'number',
+        //     description: 'keep only the specified number of major versions',
+        // },
+        // 'minor-versions': {
+        //     alias: 'minor',
+        //     type: 'number',
+        //     description:
+        //         'keep only the specified number of minor versions per major version',
+        // },
+        // 'patch-versions': {
+        //     alias: 'patch',
+        //     type: 'number',
+        //     description:
+        //         'keep only the specified number of patch versions per minor version',
+        // },
+        yes,
+        ...options,
+    });
+// .positional('ranges', {
+//     type: 'string',
+//     description: 'version ranges to purge',
+//     array: true,
+// });
+
+export async function handler<T extends Args<ReturnType<typeof builder>>>(
+    args: T
+): Promise<void> {
+    const pending: version[] = [];
+    const options = getOptions(args);
+    const metadata = refreshMetadata(
+        loadMetadata(options.out),
+        options.out,
+        options.versions.stable,
+        options.versions.dev
+    ) as refreshedMetadata;
+
+    if (args.stale)
+        pending.push(
+            ...getStale(
+                metadata.versions,
+                options.out,
+                options.versions.stable,
+                options.versions.dev
+            )
+        );
+
+    if (pending.length === 0) {
+        console.log('Nothing to purge!');
+        return;
+    }
+
+    console.log(
+        (args.yes ? 'Purging:' : 'Pending purge:')
+            .concat(EOL)
+            .concat(
+                pending
+                    .map(
+                        (v) =>
+                            `- ${relative(process.cwd(), join(options.out, v))}`
+                    )
+                    .join(EOL)
+            )
+    );
+
+    if (
+        args.yes ||
+        (
+            await prompts({
+                name: 'confirm',
+                type: 'confirm',
+                initial: false,
+                message: 'Purge docs for these versions?',
+            })
+        ).confirm
+    ) {
+        if (!args.yes) console.log('');
+
+        for (const version of pending) {
+            const dir = resolve(join(options.out, version));
+            if (isDir(dir)) rmSync(dir, { recursive: true, force: true });
+        }
+    }
+}
+
+export const isStable = (version: version, stable: version | 'auto'): boolean =>
+    getVersionAlias(version, stable) === 'stable';
+
+export const isDev = (version: version, dev: version | 'auto'): boolean =>
+    getVersionAlias(version, undefined, dev) === 'dev';
+
+export const isPinned = (
+    version: version,
+    stable: version | 'auto',
+    dev: version | 'auto'
+): boolean =>
+    (stable !== 'auto' &&
+        getSemanticVersion(version) === getSemanticVersion(stable)) ||
+    (dev !== 'auto' && getSemanticVersion(version) === getSemanticVersion(dev));
+
+export const isStale = (
+    version: version,
+    versions: version[],
+    stable: version | 'auto',
+    dev: version | 'auto'
+): boolean =>
+    !isPinned(version, stable, dev) &&
+    isDev(version, dev) &&
+    !!versions
+        .filter((v) => isStable(v, stable))
+        .find((s) => gt(s, version, true));
+
+export const getStale = (
+    versions: version[],
+    docsPath: string,
+    stable: version | 'auto',
+    dev: version | 'auto'
+): version[] =>
+    versions.filter(
+        (v, _, s) =>
+            isDir(resolve(join(docsPath, v))) && isStale(v, s, stable, dev)
+    );

--- a/src/commands/synchronize.ts
+++ b/src/commands/synchronize.ts
@@ -1,0 +1,166 @@
+import { metadata } from 'typedoc-plugin-versions';
+import {
+    getMetadataPath,
+    loadMetadata,
+    refreshMetadata,
+    saveMetadata,
+    makeJsKeys,
+    makeAliasLink,
+    makeMinorVersionLinks,
+    getSemanticVersion,
+} from 'typedoc-plugin-versions/src/etc/utils';
+import diff from 'cli-diff';
+import { readFileSync, writeFileSync } from 'fs-extra';
+import { EOL } from 'os';
+import { join, relative, resolve } from 'path';
+import prompts from 'prompts';
+import { options, yes } from './builders';
+import { getOptions, isFile, isDir, unlinkBrokenSymlinks } from '../utils';
+import { Args, refreshedMetadata } from '../';
+
+export const command = ['synchronize', 'sync'];
+export const description = 'synchronize metadata and symlinks';
+export const builder = {
+    symlinks: {
+        type: 'boolean' as const,
+        description: 'always synchronize symlinks',
+        default: false,
+    },
+    yes,
+    ...options,
+};
+
+export async function handler<T extends Args<typeof builder>>(
+    args: T
+): Promise<void> {
+    const options = getOptions(args);
+
+    const metadata = loadMetadata(options.out);
+    const refreshedMetadata = refreshMetadata(
+        metadata,
+        options.out,
+        options.versions.stable,
+        options.versions.dev
+    ) as refreshedMetadata;
+
+    const packageVersion = getSemanticVersion();
+    if (!isDir(resolve(join(options.out, packageVersion)))) {
+        console.error(
+            `Missing docs for package.json version: ${packageVersion}${EOL}Did you forget to run typedoc?`
+        );
+        process.exit(1);
+    }
+
+    const changes = getDiffs(options.out, metadata, refreshedMetadata);
+    if (!args.symlinks && changes.length === 0) {
+        console.log('Already up-to-date.');
+        return;
+    } else if (changes.length > 0) {
+        console.log(
+            (args.yes ? 'Synchonizing:' : 'Pending synchronization:')
+                .concat(`${EOL}${EOL}`)
+                .concat(
+                    changes
+                        .map((change) => `${change.label}:${EOL}${change.diff}`)
+                        .join(EOL)
+                )
+        );
+    }
+
+    let symlinks = args.symlinks;
+    if (
+        changes.length > 0 &&
+        (args.yes ||
+            (
+                await prompts({
+                    name: 'confirm',
+                    type: 'confirm',
+                    initial: false,
+                    message: 'Apply pending synchronizations?',
+                })
+            ).confirm)
+    ) {
+        if (!args.yes) console.log('');
+
+        for (const change of changes) {
+            console.time(change.label);
+            change.save();
+            console.timeEnd(change.label);
+        }
+
+        symlinks = true;
+    }
+
+    if (symlinks) {
+        const symlinksLabel = 'symlinks';
+        console.time(symlinksLabel);
+        unlinkBrokenSymlinks(options.out);
+        makeSymlinks(options.out, refreshedMetadata);
+        console.timeEnd(symlinksLabel);
+    }
+}
+
+export function getDiffs(
+    docsPath: string,
+    metadata: metadata,
+    refreshedMetadata: refreshedMetadata
+): {
+    diff: ReturnType<typeof diff>;
+    label: string;
+    save: (output?: string) => void;
+}[] {
+    const versionsPath = resolve(join(docsPath, 'versions.js'));
+    const versionsOutput = refreshVersionJs(refreshedMetadata);
+    const indexPath = resolve(join(docsPath, 'index.html'));
+    const indexOutput = refreshIndexHtml(refreshedMetadata);
+    return [
+        {
+            diff: getMetadataDiff(metadata, refreshedMetadata),
+            label: relative(process.cwd(), getMetadataPath(docsPath)),
+            save: () => saveMetadata(refreshedMetadata, docsPath),
+        },
+        {
+            diff: diff(
+                isFile(versionsPath)
+                    ? readFileSync(versionsPath, { encoding: 'utf8' })
+                    : '',
+                versionsOutput
+            ),
+            label: relative(process.cwd(), versionsPath),
+            save: () => writeFileSync(versionsPath, versionsOutput),
+        },
+        {
+            diff: diff(
+                isFile(indexPath)
+                    ? readFileSync(indexPath, { encoding: 'utf8' })
+                    : '',
+                refreshIndexHtml(refreshedMetadata)
+            ),
+            label: relative(process.cwd(), indexPath),
+            save: () => writeFileSync(indexPath, indexOutput),
+        },
+    ].filter((x) => x.diff.length > 0);
+}
+
+export const getMetadataDiff = (
+    left: metadata,
+    right: metadata
+): ReturnType<typeof diff> =>
+    diff(
+        JSON.stringify(left, undefined, 2).concat(EOL),
+        JSON.stringify(right, undefined, 2).concat(EOL)
+    );
+
+export const refreshVersionJs = (metadata: refreshedMetadata) =>
+    makeJsKeys(metadata);
+
+export const refreshIndexHtml = (metadata: refreshedMetadata) =>
+    `<meta http-equiv="refresh" content="0; url=${
+        metadata.stable ? 'stable' : 'dev'
+    }"/>`;
+
+export function makeSymlinks(dir: string, metadata: refreshedMetadata): void {
+    makeAliasLink('stable', dir, metadata.stable ?? metadata.dev);
+    makeAliasLink('dev', dir, metadata.dev ?? metadata.stable);
+    makeMinorVersionLinks(metadata.versions, dir);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,28 @@
+import { metadata, version, versionsOptions } from 'typedoc-plugin-versions';
+import {
+    ArgumentsCamelCase,
+    Argv,
+    InferredOptionTypes,
+    Options as BuilderOptions,
+} from 'yargs';
+
+export * as purge from './commands/purge';
+export * as synchronize from './commands/synchronize';
+export * from './utils';
+
+export interface Options {
+    out: string;
+    versions: Required<versionsOptions>;
+}
+
+export type Args<O> = O extends Argv<infer R>
+    ? ArgumentsCamelCase<R>
+    : O extends { [key: string]: BuilderOptions }
+    ? ArgumentsCamelCase<InferredOptionTypes<O>>
+    : unknown;
+
+export type refreshedMetadata = metadata & { versions: version[] } & (
+        | { stable: version; dev: version }
+        | { stable: version }
+        | { dev: version }
+    );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -193,3 +193,12 @@ export function exclude<T>(
             : !elementsOrPredicate.includes(v)
     );
 }
+
+export const coerceStringArray = (array: string[]) =>
+    array.map((value) => {
+        value = value.trim();
+        return (value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'"))
+            ? [...value].slice(1, -1).join('')
+            : value;
+    });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,125 @@
+import {
+    pathExistsSync,
+    statSync,
+    lstatSync,
+    readdirSync,
+    readJsonSync,
+    readlinkSync,
+    unlinkSync,
+} from 'fs-extra';
+import { join, relative, resolve } from 'path';
+import {
+    findConfigFile,
+    getParsedCommandLineOfConfigFile,
+    sys,
+    formatDiagnosticsWithColorAndContext,
+} from 'typescript';
+import { options, out } from './commands/builders';
+import { Options, Args } from './';
+
+export function getOptions<O extends typeof options>(args: Args<O>): Options {
+    const tsconfig = getParsedCommandLineOfConfigFile(
+        args.tsconfig,
+        {},
+        {
+            ...sys,
+            onUnRecoverableConfigFileDiagnostic: (diagnostic) =>
+                console.debug(
+                    formatDiagnosticsWithColorAndContext([diagnostic], {
+                        getCanonicalFileName: resolve,
+                        getCurrentDirectory: () => process.cwd(),
+                        getNewLine: () => sys.newLine,
+                    })
+                ),
+        }
+    );
+    const typedoc = readJsonSync(args.typedoc);
+
+    const out = resolve(
+        args.out ??
+            typedoc.out ??
+            tsconfig?.raw.typedocOptions?.out ??
+            join(process.cwd(), 'docs')
+    );
+
+    if (!isDir(out)) {
+        throw new Error(
+            `Directory does not exist: ${relative(process.cwd(), out)}`
+        );
+    }
+
+    return {
+        out,
+        versions: {
+            stable: 'auto',
+            dev: 'auto',
+            domLocation: 'false',
+            ...(tsconfig?.raw.typedocOptions?.versions ?? {}),
+            ...(typedoc.versions ?? {}),
+        },
+    };
+}
+
+export function getOut<O extends { out: typeof out }>(args: Args<O>): string {
+    if (args.out) return args.out;
+    else if (isOptionsArgs(args)) return getOptions(args).out;
+    else throw new Error(`Could not parse 'out': ${JSON.stringify(args)}`);
+}
+
+export const isOptionsArgs = (obj: unknown): obj is Args<typeof options> =>
+    typeof obj === 'object' &&
+    obj !== null &&
+    'typedoc' in obj &&
+    'tsconfig' in obj;
+
+export function findFile(path?: string, fallbackPaths?: string[]): string;
+export function findFile(path?: string, tsconfig?: boolean): string;
+export function findFile(
+    path = process.cwd(),
+    fallbackPathsOrTsConfig: string[] | boolean = []
+): string {
+    const tsconfig =
+        typeof fallbackPathsOrTsConfig === 'boolean' && fallbackPathsOrTsConfig;
+    const fallbackPaths =
+        typeof fallbackPathsOrTsConfig !== 'boolean'
+            ? fallbackPathsOrTsConfig
+            : [];
+
+    path = resolve(path);
+
+    if (!pathExistsSync(path))
+        throw new Error(
+            `Path does not exist: ${relative(process.cwd(), path)}`
+        );
+
+    const file = tsconfig
+        ? findConfigFile(path, isFile)
+        : [path, ...fallbackPaths.map((p) => join(path, p))].find(isFile);
+
+    if (!file)
+        throw new Error(
+            `File does not exist: ${relative(process.cwd(), path)}`
+        );
+
+    return resolve(file);
+}
+
+export const isFile = (path: string): boolean =>
+    statSync(path, { throwIfNoEntry: false })?.isFile() ?? false;
+
+export const isDir = (path: string): boolean =>
+    statSync(path, { throwIfNoEntry: false })?.isDirectory() ?? false;
+
+export const isSymlink = (path: string): boolean =>
+    lstatSync(path, { throwIfNoEntry: false })?.isSymbolicLink() ?? false;
+
+export const isBrokenSymlink = (path: string): boolean =>
+    isSymlink(path) && !pathExistsSync(readlinkSync(path));
+
+export function unlinkBrokenSymlinks(dir: string): void {
+    for (const path of readdirSync(dir)
+        .map((p) => join(dir, p))
+        .filter(isBrokenSymlink)) {
+        unlinkSync(path);
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,7 +99,7 @@ export function findTsConfigFile(path = process.cwd()): string {
 
 export async function findFile(
     path = process.cwd(),
-    fallbackPaths: string[] = []
+    fallbackPaths: readonly string[] = []
 ): Promise<string> {
     path = resolve(path);
 
@@ -155,4 +155,41 @@ export async function unlinkBrokenSymlinks(dir: string): Promise<void> {
     const paths = (await readdir(dir)).map((path) => join(dir, path));
     const brokenSymLinks = await filter(paths, isBrokenSymlink);
     await each(brokenSymLinks, unlink);
+}
+
+export function drop<T>(array: T[], predicate: (value: T) => boolean): T[];
+export function drop<T>(array: T[], elements: readonly T[]): T[];
+export function drop<T>(
+    array: T[],
+    elementsOrPredicate: readonly T[] | ((value: T) => boolean)
+): T[] {
+    const toBeDropped =
+        typeof elementsOrPredicate === 'function'
+            ? array.filter(elementsOrPredicate)
+            : elementsOrPredicate;
+
+    const dropped = [];
+    for (const value of toBeDropped) {
+        const i = array.indexOf(value);
+        if (i >= 0) {
+            dropped.push(...array.splice(i, 1));
+        }
+    }
+    return dropped;
+}
+
+export function exclude<T>(
+    array: readonly T[],
+    predicate: (value: T) => boolean
+): T[];
+export function exclude<T>(array: readonly T[], elements: readonly T[]): T[];
+export function exclude<T>(
+    array: readonly T[],
+    elementsOrPredicate: readonly T[] | ((value: T) => boolean)
+): T[] {
+    return array.filter((v) =>
+        typeof elementsOrPredicate === 'function'
+            ? !elementsOrPredicate(v)
+            : !elementsOrPredicate.includes(v)
+    );
 }


### PR DESCRIPTION
## Changes in this pull request
- Adds `purge` command
  - Useful for deleting old doc builds
  - Does not synchronize metadata and symlinks after the operation - run the `sync` command for this
  - Displays a confirmation prompt, can be bypassed via `--yes` flag
  - With no arguments, merely purges stale docs, i.e. versions considered `dev` by typedoc-plugin-versions which have a newer `stable` version
  - Resolves #1, resolves citkane/typedoc-plugin-versions#12
- Adds `syncrhonize` command
  - Keeps metadata and symlinks in sync, useful when old docs have been deleted either via hand or via the `purge` command
  - Displays a confirmation prompt, can be bypassed via `--yes` flag
  - Resolves #2 
- Adds dependency on `async` library for running async operations concurrently