### PR TITLE
Remove the `typedoc-plugin` etc. keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc-plugin-versions-cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A companion CLI tool for typedoc-plugins-versions.",
   "main": "./dist/index.js",
   "bin": {
@@ -37,9 +37,7 @@
     "ci-cd",
     "ci",
     "cd",
-    "cid",
-    "typedoc-plugin",
-    "typedocplugin"
+    "cid"
   ],
   "author": "Tobey Blaber (https://github.com/toebeann)",
   "homepage": "https://toebeann.github.io/typedoc-plugin-versions-cli",


### PR DESCRIPTION
## Changes in this pull request
- Removes the `typedoc-plugin` and `typedocplugin` keywords from `package.json`
- Bumps version to `0.1.4`

## Reasoning
While the `typedoc-plugin` keywords allow the CLI tool to be listed under [TypeDoc's Plugins page](https://typedoc.org/guides/plugins/), which is useful for discoverability, they also signal to TypeDoc to load this module as a plugin, which results in the typedoc CLI command refusing to run and the following error output:

```text
error Invalid structure in plugin typedoc-plugin-versions-cli, no load function found.
```

I have considered adding a dummy `load` function to `index.ts` to allow TypeDoc to successfully load the module, however this feels like a hack rather than a good solution.

Therefore, we will have to live without being listed on the TypeDoc Plugins page, and rely on discovery via [`typedoc-plugin-versions' README`](https://github.com/citkane/typedoc-plugin-versions#readme) etc.