### PR TITLE
v0.1.5-alpha.1.1

### DIFF
--- a/.github/workflows/publish-code-coverage.yml
+++ b/.github/workflows/publish-code-coverage.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup node.js @ 16
+      - name: Setup node.js @ lts
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: lts/*
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Clean up gh-pages
         run: rm -rf gh-pages
 
-      - name: Setup node.js @ 16
+      - name: Setup node.js @ lts
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: lts/*
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup node.js @ 16
+      - name: Setup node.js @ lts
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: lts/*
 
       - name: Get npm cache directory
         id: npm-cache
@@ -47,9 +47,6 @@ jobs:
 
       - name: Build
         run: npm run build
-
-      - name: Shrinkwrap
-        run: npm shrinkwrap
 
       - name: Publish to npm 🚀
         uses: JS-DevTools/npm-publish@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typedoc-plugin-versions-cli",
-  "version": "0.1.5-alpha.1",
+  "version": "0.1.5-alpha.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typedoc-plugin-versions-cli",
-      "version": "0.1.5-alpha.1",
+      "version": "0.1.5-alpha.1.1",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc-plugin-versions-cli",
-  "version": "0.1.5-alpha.1",
+  "version": "0.1.5-alpha.1.1",
   "description": "A companion CLI tool for typedoc-plugins-versions.",
   "main": "./dist/index.js",
   "bin": {


### PR DESCRIPTION
- Updates workflows to use Node LTS 09464e086ca26acdec7aadc2f9409e3cd6d0d2d5
- No longer run `npm shrinkwrap` prior to `npm publish` to attempt to resolve an issue for downstream packages where they cannot run `npm ci` in CICD except for on `darwin` d070978dc37ddbbf3db24558742839d807a1c876